### PR TITLE
feat: add oklab display to color swatches

### DIFF
--- a/src/components/color-swatch.component.ts
+++ b/src/components/color-swatch.component.ts
@@ -27,6 +27,7 @@ import { ColorSwatch } from "../types/theme.types";
         >
           <p class="font-mono">{{ swatch().hex.toUpperCase() }}</p>
           <p class="font-mono">{{ swatch().hsl }}</p>
+          <p class="font-mono">{{ swatch().oklab }}</p>
           <p class="font-mono">{{ swatch().cssVar }}</p>
         </div>
       </div>

--- a/src/types/theme.types.ts
+++ b/src/types/theme.types.ts
@@ -11,10 +11,17 @@ export interface HSLColor {
   l: number;
 }
 
+export interface OklabColor {
+  l: number;
+  a: number;
+  b: number;
+}
+
 export interface ColorSwatch {
   name: string;
   hex: string;
   hsl: string;
+  oklab: string;
   cssVar: string;
 }
 


### PR DESCRIPTION
## Summary
- add Oklab color conversion and formatting utilities
- extend color swatches to show Oklab values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68962faa6a148320a435fe41c2dfe04c